### PR TITLE
Support getter/setter

### DIFF
--- a/__testfixtures__/extract-calls-fake.input.js
+++ b/__testfixtures__/extract-calls-fake.input.js
@@ -1,5 +1,39 @@
 const sinon = require("sinon");
 
-let o = {foo: function() {}};
-sinon.stub(o, 'foo', function () { return 'boom'; }).toString();
-sinon.stub(o, 'bar');
+let obj = {
+  example: 'oldValue',
+  prop: 'foo',
+  foo: function () {
+  }
+};
+// function
+sinon.stub(obj, 'foo', function () {
+  return 'boom';
+}).toString();
+sinon.stub(obj, 'bar');
+
+// Arrow Function
+sinon.stub(obj, 'foo', () => {});
+
+// getter
+const fakeGetter = function () {
+  return false;
+};
+sinon.stub(obj, "prop", {get: fakeGetter});
+sinon.stub(obj, 'prop', {
+  get() {
+    return false;
+  }
+});
+
+// setter
+function setterFn(val) {
+  obj.example = val;
+}
+
+sinon.stub(obj, 'prop', {set: setterFn});
+sinon.stub(obj, 'prop', {
+  set(val) {
+    obj.example = val;
+  }
+});

--- a/__testfixtures__/extract-calls-fake.output.js
+++ b/__testfixtures__/extract-calls-fake.output.js
@@ -1,5 +1,35 @@
 const sinon = require("sinon");
 
-let o = {foo: function() {}};
-sinon.stub(o, 'foo').callsFake(function () { return 'boom'; }).toString();
-sinon.stub(o, 'bar');
+let obj = {
+  example: 'oldValue',
+  prop: 'foo',
+  foo: function () {
+  }
+};
+// function
+sinon.stub(obj, 'foo').callsFake(function () {
+  return 'boom';
+}).toString();
+sinon.stub(obj, 'bar');
+
+// Arrow Function
+sinon.stub(obj, 'foo').callsFake(() => {});
+
+// getter
+const fakeGetter = function () {
+  return false;
+};
+sinon.stub(obj, "prop").get(fakeGetter);
+sinon.stub(obj, 'prop').get(function() {
+  return false;
+});
+
+// setter
+function setterFn(val) {
+  obj.example = val;
+}
+
+sinon.stub(obj, 'prop').set(setterFn);
+sinon.stub(obj, 'prop').set(function(val) {
+  obj.example = val;
+});

--- a/extract-calls-fake.js
+++ b/extract-calls-fake.js
@@ -1,11 +1,3 @@
-function replaceGetter() {
-
-}
-
-function replaceSetter() {
-
-}
-
 function transformer(file, api) {
   const j = api.jscodeshift;
   return j(file.source)

--- a/extract-calls-fake.js
+++ b/extract-calls-fake.js
@@ -1,3 +1,11 @@
+function replaceGetter() {
+
+}
+
+function replaceSetter() {
+
+}
+
 function transformer(file, api) {
   const j = api.jscodeshift;
   return j(file.source)
@@ -16,15 +24,56 @@ function transformer(file, api) {
     })
     .replaceWith(path => {
         let callNode = path.node;
-        // console.log('EXP', path.node)
-        let fakeFn = callNode.arguments.pop();
-        return j.memberExpression(
-          callNode,
-          j.callExpression(
-            j.identifier('callsFake'),
-            [fakeFn]
-          )
-        );
+        // console.log('EXP', path.node);
+        let fakeImplementationNode = callNode.arguments.pop();
+        // sinon.stub(obj, 'foo', function () { return 'boom'; })
+        // sinon.stub(obj, 'foo', () => {})
+        if (fakeImplementationNode.type === "FunctionExpression" || fakeImplementationNode.type === "ArrowFunctionExpression") {
+          return j.memberExpression(
+            callNode,
+            j.callExpression(
+              j.identifier('callsFake'),
+              [fakeImplementationNode]
+            )
+          );
+        } else if (fakeImplementationNode.type === "ObjectExpression") {
+          // getter/setter
+          const properties = fakeImplementationNode.properties;
+          if (!properties) {
+            return;
+          }
+          // { get: fake, set: fake } pattern is not supported yet.
+          if (properties.length > 1) {
+            throw new Error("NOT support");
+          }
+          const property = properties[0];
+          if (property.kind !== "init" || !property.key) {
+            return;
+          }
+          if (property.key.name !== "get" && property.key.name !== "set") {
+            return; // this is not getter or setter
+          }
+          const isGetter = property.key.name === "get";
+          // => stub(obj, "prop").get(fn)
+          if (isGetter) {
+            return j.memberExpression(
+              callNode,
+              j.callExpression(
+                j.identifier('get'),
+                [property.value]
+              )
+            );
+          } else {
+            // => stub(obj, "prop").set(fn)
+            return j.memberExpression(
+              callNode,
+              j.callExpression(
+                j.identifier('set'),
+                [property.value]
+              )
+            );
+          }
+        }
       }
     ).toSource();
 }


### PR DESCRIPTION
This PR resolve #3 .

Example code from http://sinonjs.org/releases/v2.1.0/stubs/

## getter

```js
const fakeGetter = function () {
  return false;
};
sinon.stub(obj, "prop", {get: fakeGetter});
sinon.stub(obj, 'prop', {
  get() {
    return false;
  }
});
```

to be

```js
const fakeGetter = function () {
  return false;
};
sinon.stub(obj, "prop").get(fakeGetter);
sinon.stub(obj, 'prop').get(function() {
  return false;
});
```

## setter

```js
function setterFn(val) {
  obj.example = val;
}

sinon.stub(obj, 'prop', {set: setterFn});
sinon.stub(obj, 'prop', {
  set(val) {
    obj.example = val;
  }
});
```

to be

```js
function setterFn(val) {
  obj.example = val;
}

sinon.stub(obj, 'prop').set(setterFn);
sinon.stub(obj, 'prop').set(function(val) {
  obj.example = val;
});
```

**Notes**:

This PR not support `get` and `set` stub pattern.

```js
// this stub have both of `get` and `set`
sinon.stub(obj, 'prop', {
  get() {
    return false;
  },
  set(value){
  }
});
```

/cc @hurrymaplelad 