### PR TITLE
eliminate sandbox references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,21 @@ Converts 3-argument calls to `sinon.stub(x,y,z)` into `sinon.stub(x,y).callsFake
 ```sh
 jscodeshift -t sinon-codemod/extract-calls-fake.js <path>
 ```
+
+#### `migrate-to-v5`
+
+Removes `sandbox` variable declaration
+
+Removes `sinon.sandbox.create();`
+
+Replaces `sandbox.restore()` with `sinon.restore()`
+
+Replaces `sandbox.stub()` with `sinon.stub()`
+
+Replaces `sandbox.spy()` with `sinon.spy()`
+
+Replaces `sandbox.mock()` with `sinon.mock()`
+
+```sh
+jscodeshift -t sinon-codemod/migrate-to-v5.js <path>
+```

--- a/__testfixtures__/migrate-to-v5.input.js
+++ b/__testfixtures__/migrate-to-v5.input.js
@@ -1,0 +1,19 @@
+const sinon = require("sinon");
+
+describe('dummy suite', () => {
+    let sandbox = null;
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('dummy test', () => {
+        sandbox.stub({}, 'dummyFunction').returns({});
+        sandbox.spy({}, 'dummyFunction');
+        sandbox.mock({});
+    })
+});

--- a/__testfixtures__/migrate-to-v5.output.js
+++ b/__testfixtures__/migrate-to-v5.output.js
@@ -1,0 +1,15 @@
+const sinon = require("sinon");
+
+describe('dummy suite', () => {
+    beforeEach(() => {});
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('dummy test', () => {
+        sinon.stub({}, 'dummyFunction').returns({});
+        sinon.spy({}, 'dummyFunction');
+        sinon.mock({});
+    })
+});

--- a/__tests__/migrate-to-v5-test.js
+++ b/__tests__/migrate-to-v5-test.js
@@ -1,0 +1,4 @@
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+describe('migrate-to-v5', () => {
+  defineTest(__dirname, 'migrate-to-v5');
+});

--- a/migrate-to-v5.js
+++ b/migrate-to-v5.js
@@ -1,0 +1,136 @@
+function transformer(file, api) {
+  const j = api.jscodeshift;
+  const source = j(file.source);
+
+  const replacer = path => {
+    path.value.callee.object.name = 'sinon';
+    return path.value;
+  };
+
+  /*
+  let sandbox = null;
+
+  ->
+
+  */
+  source
+    .find(j.VariableDeclaration, {declarations: [{id: {name: 'sandbox'}}]})
+    .remove();
+
+  /*
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  ->
+
+  beforeEach(() => {});
+  */
+  source
+    .find(j.AssignmentExpression, {
+      right: {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: {
+            type: 'MemberExpression',
+            object: {
+              name: 'sinon'
+            },
+            property: {
+              name: 'sandbox'
+            }
+          }
+        }
+      }
+    })
+    .remove();
+
+  /*
+  sandbox.stub({}, 'dummyFunction').returns({});
+
+  ->
+
+  sinon.stub({}, 'dummyFunction').returns({});
+  */
+  source
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'sandbox'
+        },
+        property: {
+          name: 'stub'
+        }
+      }
+    })
+    .replaceWith(replacer);
+
+  /*
+  sandbox.spy({}, 'dummyFunction');
+
+  ->
+
+  sinon.spy({}, 'dummyFunction');
+  */
+  source
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'sandbox'
+        },
+        property: {
+          name: 'spy'
+        }
+      }
+    })
+    .replaceWith(replacer);
+
+  /*
+  sandbox.mock({}));
+
+  ->
+
+  sinon.mock({});
+  */
+  source
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'sandbox'
+        },
+        property: {
+          name: 'mock'
+        }
+      }
+    })
+    .replaceWith(replacer);
+
+  /*
+  sandbox.restore();
+
+  ->
+
+  sinon.restore();
+  */
+  source
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'sandbox'
+        },
+        property: {
+          name: 'restore'
+        }
+      }
+    })
+    .replaceWith(replacer);
+
+  return source.toSource();
+}
+
+module.exports = transformer;


### PR DESCRIPTION
This is bare minimum transform I needed to migrate my codebase to v5+. It will not cover all api, but maybe will come usefull for somebody